### PR TITLE
Split auto-merge to two commands

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Tox test
     strategy:
       matrix:
-        tox_env: [py36, py37, py38, py39, py310, py311, py312]
+        tox_env: [py38, py39, py310, py311, py312]
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest
     steps:

--- a/auto-merger
+++ b/auto-merger
@@ -30,39 +30,29 @@ import sys
 
 import click
 
-from auto_merger.merger import AutoMerger
-from auto_merger.utils import setup_logger
 
+from auto_merger.config import GlobalConfig
+from auto_merger.utils import setup_logger
+from auto_merger.cli.pr_checker import pr_checker
+from auto_merger.cli.merger import merger
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@click.group("auto-merger")
 @click.option("-d", "--debug", is_flag=True, help="Enable debug logs")
-@click.option("--print-results", is_flag=True, help="Prints readable summary")
-@click.option("--github-labels", required=True, multiple=True,
-              help="Specify Git Hub labels to meet criteria")
-@click.option("--blocking-labels", multiple=True,
-              help="Specify Git Hub labels that blocks PR to merge")
-@click.option("--send-email", multiple=True, help="Specify email addresses to which the mail will be sent.")
-@click.option("--approvals",
-              default=2, type=int,
-              help="Specify number of approvals to automatically merge PR. Default 2")
-def auto_merger(debug, print_results, github_labels, blocking_labels, approvals, send_email):
-    am = AutoMerger(github_labels, blocking_labels,  approvals)
+@click.pass_context
+def auto_merger(ctx, debug):
+    ctx.obj = GlobalConfig(debug=debug)
     if debug:
         setup_logger("auto-merger", level=logging.DEBUG)
+        logger.debug("Logging set to DEBUG")
     else:
         setup_logger("auto-merger", level=logging.INFO)
-    ret_value = am.check_all_containers()
-    if ret_value != 0:
-        sys.exit(2)
-    if print_results:
-        am.print_blocked_pull_request()
-        am.print_approval_pull_request()
-    if not am.send_results(send_email):
-        sys.exit(1)
-    sys.exit(ret_value)
+        logger.debug("Logging set to INFO")
+
+auto_merger.add_command(pr_checker)
+auto_merger.add_command(merger)
 
 
 if __name__ == "__main__":
-    auto_merger()
+    auto_merger(obj={})

--- a/auto_merger/api.py
+++ b/auto_merger/api.py
@@ -54,7 +54,7 @@ def merger(print_results, merger_labels, approvals, pr_lifetime, send_email) -> 
     if ret_value != 0:
         return ret_value
     if print_results:
-        auto_merger.print_approval_pull_request()
+        auto_merger.print_pull_request_to_merge()
     if not auto_merger.send_results(send_email):
         return 1
     return ret_value

--- a/auto_merger/api.py
+++ b/auto_merger/api.py
@@ -1,0 +1,60 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+import sys
+
+from pathlib import Path
+from typing import Dict
+
+from auto_merger.pr_checker import PRStatusChecker
+from auto_merger.merger import AutoMerger
+
+logger = logging.getLogger(__name__)
+
+
+def pr_checker(print_results, github_labels, blocking_labels, approvals, send_email) -> int:
+    """
+    Checks NVR from brew build against pulp
+    """
+    pr_status_checker = PRStatusChecker(github_labels, blocking_labels, approvals)
+    ret_value = pr_status_checker.check_all_containers()
+    if ret_value != 0:
+        return ret_value
+    if print_results:
+        pr_status_checker.print_blocked_pull_request()
+        pr_status_checker.print_approval_pull_request()
+    if not pr_status_checker.send_results(send_email):
+        return 1
+    return ret_value
+
+
+def merger(print_results, merger_labels, approvals, pr_lifetime, send_email) -> int:
+    auto_merger = AutoMerger(merger_labels, approvals, pr_lifetime)
+    ret_value = auto_merger.check_all_containers()
+    if ret_value != 0:
+        return ret_value
+    if print_results:
+        auto_merger.print_approval_pull_request()
+    if not auto_merger.send_results(send_email):
+        return 1
+    return ret_value

--- a/auto_merger/cli/merger.py
+++ b/auto_merger/cli/merger.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 @click.option("--approvals",
               default=2, type=int,
               help="Specify number of approvals to automatically merge PR. Default 2")
-@click.option("--pr-lifetime", int=1, help="Specify a smallest time for which PR should opened")
+@click.option("--pr-lifetime", default=1, type=int, help="Specify a smallest time for which PR should opened")
 @pass_global_config
 def merger(ctx, print_results, merger_labels, approvals, pr_lifetime, send_email):
     logger.debug(ctx.debug)

--- a/auto_merger/cli/merger.py
+++ b/auto_merger/cli/merger.py
@@ -1,0 +1,47 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import logging
+import click
+import sys
+
+from auto_merger.config import pass_global_config
+from auto_merger import api
+logger = logging.getLogger(__name__)
+
+
+@click.command("merger")
+@click.option("--print-results", is_flag=True, help="Prints readable summary")
+@click.option("--merger-labels", required=True, multiple=True,
+              help="Specify Git Hub labels to meet criteria")
+@click.option("--send-email", multiple=True, help="Specify email addresses to which the mail will be sent.")
+@click.option("--approvals",
+              default=2, type=int,
+              help="Specify number of approvals to automatically merge PR. Default 2")
+@click.option("--pr-lifetime", int=1, help="Specify a smallest time for which PR should opened")
+@pass_global_config
+def merger(ctx, print_results, merger_labels, approvals, pr_lifetime, send_email):
+    logger.debug(ctx.debug)
+    ret_value = api.merger(print_results, merger_labels, approvals, pr_lifetime, send_email)
+    sys.exit(ret_value)
+

--- a/auto_merger/cli/pr_checker.py
+++ b/auto_merger/cli/pr_checker.py
@@ -1,0 +1,49 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import logging
+import click
+import sys
+
+from auto_merger.config import pass_global_config
+from auto_merger import api
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("pr-checker")
+@click.option("--print-results", is_flag=True, help="Prints readable summary")
+@click.option("--github-labels", required=True, multiple=True,
+              help="Specify Git Hub labels to meet criteria")
+@click.option("--blocking-labels", multiple=True,
+              help="Specify Git Hub labels that blocks PR to merge")
+@click.option("--send-email", multiple=True, help="Specify email addresses to which the mail will be sent.")
+@click.option("--approvals",
+              default=2, type=int,
+              help="Specify number of approvals to automatically merge PR. Default 2")
+@pass_global_config
+def pr_checker(ctx, print_results, github_labels, blocking_labels, approvals, send_email):
+    logger.debug(ctx.debug)
+    ret_value = api.pr_checker(print_results, github_labels, blocking_labels, approvals, send_email)
+    sys.exit(ret_value)
+

--- a/auto_merger/config.py
+++ b/auto_merger/config.py
@@ -1,0 +1,32 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import click
+
+
+class GlobalConfig(object):
+    def __init__(self, debug: bool = False):
+        self.debug = debug
+
+
+pass_global_config = click.make_pass_decorator(GlobalConfig)

--- a/auto_merger/merger.py
+++ b/auto_merger/merger.py
@@ -44,13 +44,11 @@ class AutoMerger:
 
     def __init__(self, github_labels, approvals: int = 2, pr_lifetime: int = 1):
         self.logger = setup_logger("AutoMerger")
-        self.github_labels = list(github_labels)
+        self.approval_labels = list(github_labels)
         self.approvals = approvals
-        self.logger.debug(f"GitHub Labels: {self.github_labels}")
+        self.logger.debug(f"GitHub Labels: {self.approval_labels}")
         self.logger.debug(f"Approvals Labels: {self.approvals}")
-        self.blocked_pr = {}
         self.pr_to_merge = {}
-        self.blocked_body = []
         self.approval_body = []
         self.repo_data: List = []
 
@@ -91,22 +89,6 @@ class AutoMerger:
             return False
         return True
 
-    def add_blocked_pr(self, pr: {}):
-        present = False
-        for stored_pr in self.blocked_pr[self.container_name]:
-            if int(stored_pr["number"]) == int(pr["number"]):
-                present = True
-        if present:
-            return
-        self.blocked_pr[self.container_name].append({
-            "number": pr["number"],
-            "pr_dict": {
-                "title": pr["title"],
-                "labels": pr["labels"]
-            }
-        })
-        self.logger.debug(f"PR {pr['number']} added to blocked")
-
     def add_approved_pr(self, pr: {}):
         self.pr_to_merge[self.container_name].append({
             "number": pr["number"],
@@ -117,22 +99,11 @@ class AutoMerger:
         })
         self.logger.debug(f"PR {pr['number']} added to approved")
 
-    def check_blocked_labels(self):
-        for pr in self.repo_data:
-            self.logger.debug(f"Check blocked: {pr}")
-            if "labels" not in pr:
-                continue
-            for label in pr["labels"]:
-                if label["name"] not in self.blocking_labels:
-                    continue
-                self.logger.debug(f"Add '{pr['number']}' to blocked PRs.")
-                self.add_blocked_pr(pr)
-
     def check_labels_to_merge(self, pr):
         if "labels" not in pr:
             return True
         for label in pr["labels"]:
-            if label["name"] in self.blocking_labels:
+            if label["name"] in self.approval_labels:
                 return False
         self.logger.debug(f"Add '{pr['number']}' to approved PRs.")
         return True
@@ -213,17 +184,10 @@ class AutoMerger:
                 self.logger.error(f"This is not correct repo {self.container_name}.")
                 self.clean_dirs()
                 continue
-            if self.container_name not in self.blocked_pr:
-                self.blocked_pr[self.container_name] = []
             if self.container_name not in self.pr_to_merge:
                 self.pr_to_merge[self.container_name] = []
             try:
                 self.get_gh_pr_list()
-                self.check_blocked_labels()
-                if len(self.blocked_pr[self.container_name]) != 0:
-                    self.logger.info(
-                        f"This pull request can not be merged {self.pr_to_merge}"
-                    )
                 self.check_pr_to_merge()
             except subprocess.CalledProcessError:
                 self.clean_dirs()
@@ -232,52 +196,31 @@ class AutoMerger:
             self.clean_dirs()
         return 0
 
-    def get_blocked_labels(self, pr_dict) -> List [str]:
-        labels = []
-        for lbl in pr_dict["labels"]:
-            labels.append(lbl["name"])
-        return labels
 
-    def print_blocked_pull_request(self):
-        # Do not print anything in case we do not have PR.
-        if not [x for x in self.blocked_pr if self.blocked_pr[x]]:
-            return 0
-        self.blocked_body.append(
-            f"Pull requests that are blocked by labels <b>[{', '.join(self.blocking_labels)}]</b><br><br>"
-        )
-
-        for container, pull_requests in self.blocked_pr.items():
-            if not pull_requests:
-                continue
-            self.blocked_body.append(f"<b>{container}<b>:")
-            self.blocked_body.append("<table><tr><th>Pull request URL</th><th>Title</th><th>Missing labels</th></tr>")
-            for pr in pull_requests:
-                blocked_labels = self.get_blocked_labels(pr["pr_dict"])
-                self.blocked_body.append(
-                    f"<tr><td>https://github.com/sclorg/{container}/pull/{pr['number']}</td>"
-                    f"<td>{pr['pr_dict']['title']}</td><td><p style='color:red;'>{' '.join(blocked_labels)}</p></td></tr>"
-                )
-            self.blocked_body.append("</table><br><br>")
-        print('\n'.join(self.blocked_body))
-
-    def print_approval_pull_request(self):
+    def print_pull_request_to_merge(self):
         # Do not print anything in case we do not have PR.
         if not [x for x in self.pr_to_merge if self.pr_to_merge[x]]:
             return 0
-        self.approval_body.append(f"Pull requests that can be merged or missing {self.approvals} approvals")
-        self.approval_body.append("<table><tr><th>Pull request URL</th><th>Title</th><th>Approval status</th></tr>")
+        to_approval: bool = False
+        pr_body: List = []
         for container, pr in self.pr_to_merge.items():
             if not pr:
                 continue
-            if int(pr["approvals"]) >= self.approvals:
-                result_pr = f"CAN BE MERGED"
-            else:
-                result_pr = f"Missing {self.approvals-int(pr['approvals'])} APPROVAL"
-            self.approval_body.append(
+            if int(pr["approvals"]) < self.approvals:
+                continue
+            to_approval = True
+            result_pr = f"CAN BE MERGED"
+            pr_body.append(
                 f"<tr><td>https://github.com/sclorg/{container}/pull/{pr['number']}</td>"
                 f"<td>{pr['pr_dict']['title']}</td><td><p style='color:red;'>{result_pr}</p></td></tr>"
             )
-        self.approval_body.append("</table><br>")
+        if to_approval:
+            self.approval_body.append(f"Pull requests that can be merged.")
+            self.approval_body.append("<table><tr><th>Pull request URL</th><th>Title</th><th>Approval status</th></tr>")
+            self.approval_body.extend(pr_body)
+            self.approval_body.append("</table><br>")
+        else:
+            self.approval_body.append("There are not pull requests to be merged.")
         print('\n'.join(self.approval_body))
 
     def send_results(self, recipients):
@@ -286,7 +229,7 @@ class AutoMerger:
             return 1
         sender_class = EmailSender(recipient_email=list(recipients))
         subject_msg = "Pull request statuses for organization https://gibhub.com/sclorg"
-        sender_class.send_email(subject_msg, self.blocked_body + self.approval_body)
+        sender_class.send_email(subject_msg, self.approval_body)
 
 
 def run():

--- a/tests/test_correct_repo.py
+++ b/tests/test_correct_repo.py
@@ -2,20 +2,20 @@
 
 from flexmock import flexmock
 
-from auto_merger.merger import AutoMerger
+from auto_merger.pr_checker import PRStatusChecker
 
 
 def test_get_gh_pr_correct_repo(get_repo_name):
-    flexmock(AutoMerger).should_receive("get_gh_json_output").and_return(get_repo_name)
-    auto_merger = AutoMerger(github_labels=[], blocking_labels=["pr/missing-review"])
+    flexmock(PRStatusChecker).should_receive("get_gh_json_output").and_return(get_repo_name)
+    auto_merger = PRStatusChecker(github_labels=[], blocking_labels=["pr/missing-review"])
     auto_merger.container_name = "s2i-nodejs-container"
     assert auto_merger.is_correct_repo()
 
 
 def test_get_gh_pr_wrong_repo(get_repo_wrong_name):
-    flexmock(AutoMerger).should_receive("get_gh_json_output").and_return(
+    flexmock(PRStatusChecker).should_receive("get_gh_json_output").and_return(
         get_repo_wrong_name
     )
-    auto_merger = AutoMerger(github_labels=[], blocking_labels=["pr/missing-review"])
+    auto_merger = PRStatusChecker(github_labels=[], blocking_labels=["pr/missing-review"])
     auto_merger.container_name = "s2i-nodejs-container"
     assert not auto_merger.is_correct_repo()

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -2,24 +2,24 @@
 
 from flexmock import flexmock
 
-from auto_merger.merger import AutoMerger
+from auto_merger.pr_checker import PRStatusChecker
 
 
 def test_get_gh_pr_list(get_pr_missing_ci):
-    flexmock(AutoMerger).should_receive("get_gh_json_output").and_return(
+    flexmock(PRStatusChecker).should_receive("get_gh_json_output").and_return(
         get_pr_missing_ci
     )
-    auto_merger = AutoMerger(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
+    auto_merger = PRStatusChecker(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
     auto_merger.container_name = "s2i-nodejs-container"
     auto_merger.get_gh_pr_list()
     assert auto_merger.repo_data
 
 
 def test_get_gh_two_pr_labels_missing(get_two_pr_missing_labels):
-    flexmock(AutoMerger).should_receive("get_gh_json_output").and_return(
+    flexmock(PRStatusChecker).should_receive("get_gh_json_output").and_return(
         get_two_pr_missing_labels
     )
-    auto_merger = AutoMerger(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
+    auto_merger = PRStatusChecker(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
     auto_merger.container_name = "s2i-nodejs-container"
     auto_merger.get_gh_pr_list()
     assert auto_merger.repo_data
@@ -27,10 +27,10 @@ def test_get_gh_two_pr_labels_missing(get_two_pr_missing_labels):
 
 
 def test_get_gh_pr_missing_ci(get_pr_missing_ci):
-    flexmock(AutoMerger).should_receive("get_gh_json_output").and_return(
+    flexmock(PRStatusChecker).should_receive("get_gh_json_output").and_return(
         get_pr_missing_ci
     )
-    auto_merger = AutoMerger(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
+    auto_merger = PRStatusChecker(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
     auto_merger.container_name = "s2i-nodejs-container"
     auto_merger.get_gh_pr_list()
     assert auto_merger.repo_data
@@ -38,8 +38,8 @@ def test_get_gh_pr_missing_ci(get_pr_missing_ci):
 
 
 def test_get_no_pr_for_merge():
-    flexmock(AutoMerger).should_receive("get_gh_json_output").and_return([])
-    auto_merger = AutoMerger(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
+    flexmock(PRStatusChecker).should_receive("get_gh_json_output").and_return([])
+    auto_merger = PRStatusChecker(github_labels=["READY-to-MERGE"], blocking_labels=["pr/missing-review", 'pr/failing-ci'])
     auto_merger.container_name = "s2i-nodejs-container"
     auto_merger.get_gh_pr_list()
     assert not auto_merger.repo_data

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py36,py37,py38,py39,py310,py311,py312
+envlist = py38,py39,py310,py311,py312
 
 [testenv]
 commands = python3 -m pytest --color=yes -vv --verbose --showlocals


### PR DESCRIPTION
Split auto-merge to two commands

In order to support automerging, we have to
split auto-merger into two commands.

There will be no overwriting command line arguments

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
