### PR TITLE
Fix for sending emails only in case there is something to merge

### DIFF
--- a/auto_merger/api.py
+++ b/auto_merger/api.py
@@ -55,7 +55,9 @@ def merger(config: Config, send_email: list[str] | None) -> int:
     if not ret_value:
         auto_merger.clean_dirs()
         return ret_value
-    auto_merger.print_pull_request_to_merge()
+    is_there_pr_to_merge = auto_merger.print_pull_request_to_merge()
+    if not is_there_pr_to_merge:
+        return 0
     auto_merger.merge_pull_requests()
     if send_email:
         if not auto_merger.send_results(send_email):

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -39,3 +39,44 @@ def test_get_gh_pr_list(pr_created_date, pr_lifetime, return_code):
         "createdAt": pr_created_date,
     }
     assert auto_merger.check_pr_lifetime(pr) == return_code
+
+
+@pytest.mark.parametrize(
+    "review_data,return_code",
+    (
+        ([{"state": "APPROVED"}], 1),
+        ([{"state": "COMMENTED"}], 0),
+        ([{"state": "APPROVED"}, {"state": "APPROVED"}], 2),
+        ([], 0),
+    ),
+)
+def test_get_approvals(review_data, return_code):
+    test_config = Config()
+    auto_merger = AutoMerger(config=test_config.get_from_dict(yaml_merger))
+    assert auto_merger.check_pr_approvals(review_data) == return_code
+
+
+@pytest.mark.parametrize(
+    "pr_to_merge,return_code,approval_body",
+    (
+        ({}, False, []),
+        ({"valkey-container": []}, False, []),
+    ),
+)
+def test_print_pull_request_to_merge_failed(pr_to_merge, return_code, approval_body):
+    test_config = Config()
+    auto_merger = AutoMerger(config=test_config.get_from_dict(yaml_merger))
+    auto_merger.pr_to_merge = pr_to_merge
+    assert auto_merger.print_pull_request_to_merge() == return_code
+    assert auto_merger.approval_body == approval_body
+
+
+def test_print_pull_request_to_merge_success():
+    test_config = Config()
+    auto_merger = AutoMerger(config=test_config.get_from_dict(yaml_merger))
+    auto_merger.pr_to_merge = {
+        "valkey-container": [{"number": 2, "pr_dict": {"title": "valkey_title"}}],
+        "httpd-container": [],
+    }
+    assert auto_merger.print_pull_request_to_merge() is True
+    assert auto_merger.approval_body != []


### PR DESCRIPTION
Fix for sending emails only in case there is something to merge
Add more tests for automerger. Move 'title' directly to structure and not to have substructures


